### PR TITLE
Toggle style FAQ's expanded by default when no javascript in browser

### DIFF
--- a/public/class-quick-and-easy-faqs-public.php
+++ b/public/class-quick-and-easy-faqs-public.php
@@ -399,9 +399,9 @@ class Quick_And_Easy_FAQs_Public {
             while ( $faqs_query->have_posts() ) :
                 $faqs_query->the_post();
                 ?>
-                <div class="qe-faq-toggle">
+                <div class="nojs qe-faq-toggle active">
                     <div class="qe-toggle-title">
-                        <strong><i class="fa fa-plus-circle"></i> <?php the_title(); ?></strong>
+                        <strong><i class="fa fa-minus-circle"></i> <?php the_title(); ?></strong>
                     </div>
                     <div class="qe-toggle-content">
                         <?php the_content(); ?>
@@ -453,9 +453,9 @@ class Quick_And_Easy_FAQs_Public {
                         while ( $faqs_query->have_posts() ) :
                             $faqs_query->the_post();
                             ?>
-                            <div class="qe-faq-toggle">
+                            <div class="nojs qe-faq-toggle active">
                                 <div class="qe-toggle-title">
-                                    <strong><i class="fa fa-plus-circle"></i> <?php the_title(); ?></strong>
+                                    <strong><i class="fa fa-minus-circle"></i> <?php the_title(); ?></strong>
                                 </div>
                                 <div class="qe-toggle-content">
                                     <?php the_content(); ?>

--- a/public/css/quick-and-easy-faqs-public.css
+++ b/public/css/quick-and-easy-faqs-public.css
@@ -37,6 +37,9 @@
   border: 1px solid #ddd;
   display: none;
 }
+.nojs.qe-faq-toggle .qe-toggle-content {
+  display: block;
+}
 .qe-faqs-filters-container {
   list-style: none;
   padding: 0;

--- a/public/js/quick-and-easy-faqs-public.js
+++ b/public/js/quick-and-easy-faqs-public.js
@@ -2,6 +2,18 @@
 	'use strict';
 
     /**
+     * FAQ's setup
+     * 
+     * Remove .nojs from .qe-faq-toggle elements, and collapse all expanded
+     * elements
+     */
+    $(function() {
+	var all_toggles = $('.qe-faq-toggle');
+	all_toggles.removeClass( 'nojs active' );
+	all_toggles.find('i.fa').removeClass( 'fa-minus-circle' ).addClass( 'fa-plus-circle' );
+    });
+
+    /**
      * FAQs Toggles
      */
     $(function() {


### PR DESCRIPTION
I am using this plugin on my site with style="toggle" and I noticed that users with javascript disabled could not access the content of FAQs since they are collapsed by default and are expanded using javascript.

So I forked the repository and set the FAQs with style="toggle" to be expanded by default when javascript is not running in the user's browser.

Thank you for this awesome plugin, hope this helps!
