### PR TITLE
Update class-shortcode.php

### DIFF
--- a/frontend/class-shortcode.php
+++ b/frontend/class-shortcode.php
@@ -103,6 +103,14 @@ class Shortcode extends Utilities {
 		$faqs_query = new FAQs_Query( $style, $filter, $orderby, $order, $limit );
 		$faqs_query->render();
 
+		wp_register_script(
+			$this->plugin_name,
+			dirname( plugin_dir_url( __FILE__ ) ) . '/frontend/js/scripts.js',
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
+		
 		wp_localize_script(
 			$this->plugin_name,
 			'qaef_object',


### PR DESCRIPTION
Add missing "wp_register_script()" because "wp_localize_script()" works only if the script has already been registered.

This issue has caused the following JS-Error:
`Uncaught ReferenceError: qaef_object is not defined
    at HTMLDivElement.<anonymous> (scripts.js?ver=1.3.9:23:28)
    at HTMLDivElement.dispatch (jquery.min.js?ver=3.7.1:2:40035)
    at v.handle (jquery.min.js?ver=3.7.1:2:38006)`